### PR TITLE
implement: cp

### DIFF
--- a/src/bin/cp.ts
+++ b/src/bin/cp.ts
@@ -1,0 +1,150 @@
+/// <reference path="../../typings/node/node.d.ts" />
+
+'use strict';
+
+import * as fs from 'fs';
+import {format} from 'util';
+
+function log(fmt: string, ...args: any[]): void {
+	let cb: Function = undefined;
+	if (args.length && typeof args[args.length-1] === 'function') {
+		cb = args[args.length-1];
+		args = args.slice(0, -1);
+	}
+	let prog = process.argv[1].split('/').slice(-1);
+	let msg = prog + ': ' + format.apply(undefined, [fmt].concat(args)) + '\n';
+
+	if (cb)
+		process.stderr.write(msg, cb);
+	else
+		process.stderr.write(msg);
+}
+
+function parseArgs(args: string[], handlers: {[n: string]: Function}): [string[], boolean] {
+	let ok = true;
+	let positionalArgs: string[] = args.filter((arg) => arg.substring(0, 1) !== '-');
+	args = args.filter((arg) => arg.substring(0, 1) === '-');
+
+	let errs = 0;
+	function done(): void {
+		errs--;
+		if (!errs)
+			process.exit(1);
+	}
+	function error(...args: any[]): void {
+		errs++;
+		ok = false;
+		// apply the arguments we've been given to log, and
+		// append our own callback.
+		log.apply(this, args.concat([done]));
+	}
+	function usage(): void {
+		errs++;
+		let prog = process.argv[1].split('/').slice(-1);
+		let flags = Object.keys(handlers).concat(['h']).sort().join('');
+		let msg = format('usage: %s [-%s] ARGS\n', prog, flags);
+		process.stderr.write(msg, done);
+	}
+
+	outer:
+		for (let i = 0; i < args.length; i++) {
+			let argList = args[i].slice(1);
+			if (argList.length && argList[0] === '-') {
+				error('unknown option "%s"', args[i]);
+				continue;
+			}
+			for (let j = 0; j < argList.length; j++) {
+				let arg = argList[j];
+				if (handlers[arg]) {
+					handlers[arg]();
+				} else if (arg === 'h') {
+					ok = false;
+					break outer;
+				} else {
+					error('invalid option "%s"', arg);
+				}
+			}
+		}
+
+	if (!ok) usage();
+
+	return [positionalArgs, ok];
+}
+
+function main (): void {
+	'use strict';
+
+	let [args, ok] = parseArgs(
+		process.argv.slice(2), {}
+	);
+
+	let length: number = args.length;
+
+	let code = 0;
+	let completed = 0;
+
+	function finished(): void {
+		completed++;
+		if (completed === length - 1) {
+			process.exit(code);
+		}
+	}
+
+	if (length < 2) {
+		code = -1;
+
+		if (!length)
+			log('missing file operand', finished);
+		else
+			log('missing destination file operand after ‘%s’', args, finished);
+
+		return;
+	}
+
+	function copy(src: string, dest: string): void {
+		fs.stat(src, function (oerr: any, stats: fs.Stats): void {
+			if (oerr) {
+				code = 1;
+				log("%s", oerr, finished);
+			} else if (stats.isFile()) {
+				fs.createReadStream(src).pipe(fs.createWriteStream(dest));
+			} else if (stats.isDirectory()) {
+				code = 1;
+				log('omitting directory ‘%s’', src, finished);
+			} else {
+				code = 1;
+				log('unrecognised command', finished);
+			}
+		});
+	}
+
+	let dest: string = args[length - 1];
+
+	fs.stat(dest, function (oerr: any, stats: fs.Stats): void {
+		if (oerr) {
+			if (length === 2 && oerr.code === "ENOENT") {
+				copy(args[0], dest);
+			} else {
+				code = 1;
+				log('fs.stat: %s', oerr, finished);
+				return;
+			}
+		} else if (length === 2 && stats.isFile()) {
+			if (args[0] !== dest) {
+				copy(args[0], dest);
+			} else {
+				code = 1;
+				log('‘%s’ and ‘%s’ are the same file', args[0], dest, finished);
+			}
+		} else if (stats.isDirectory()) {
+			for (let i = 0, end = length - 1; i < end; i++) {
+				copy(args[i], dest + '/' + args[i]);
+			}
+		} else {
+			code = 1;
+			log("target ‘%s’ is not a directory ", dest, finished);
+		}
+	});
+}
+
+main();

--- a/src/bin/cp.ts
+++ b/src/bin/cp.ts
@@ -80,25 +80,25 @@ function main (): void {
 
 	let length: number = args.length;
 
+	if (!length) {
+		let prog = process.argv[1].split('/').slice(-1);
+		process.stderr.write(prog + ': ' + 'missing file operand\n');
+		process.exit(-1);
+	}
+
 	let code = 0;
 	let completed = 0;
 
 	function finished(): void {
 		completed++;
-		if (completed === length - 1) {
+		if (completed === length) {
 			process.exit(code);
 		}
 	}
 
-	if (length < 2) {
+	if (length === 1) {
 		code = -1;
-
-		if (!length)
-			log('missing file operand', finished);
-		else
-			log('missing destination file operand after ‘%s’', args, finished);
-
-		return;
+		log('missing destination file operand after ‘%s’', args, finished);
 	}
 
 	function copy(src: string, dest: string): void {

--- a/src/bin/cp.ts
+++ b/src/bin/cp.ts
@@ -100,7 +100,13 @@ function main (): void {
 		return;
 	}
 
-	function onStreamError(err: Error): void {
+	function onReadStreamError(err: Error): void {
+		code = 1;
+		log(err.message);
+		this.close();
+	}
+
+	function onWriteStreamError(err: Error): void {
 		code = 1;
 		log(err.message);
 		this.end();
@@ -113,11 +119,11 @@ function main (): void {
 				log(oerr.message, finished);
 			} else if (stats.isFile()) {
 				let rs: any = fs.createReadStream(src);
-				rs.on('error', onStreamError);
+				rs.on('error', onReadStreamError);
 
 				let ws: any = fs.createWriteStream(dest);
-				ws.on('error', onStreamError);
-				ws.on('close', finished);
+				ws.on('error', onWriteStreamError);
+				ws.on('finish', finished);
 
 				rs.pipe(ws);
 			} else if (stats.isDirectory()) {


### PR DESCRIPTION
The cases being covered here includes:

1. If no argument -> err.
2. If 1 argument -> err.
3. For 2 arguments:
    a. If second argument is not a directory but contains a slash -> err or otherwise will create a new file
    b. If second argument is an already existing file -> overwrite
4. It will always check if all the arguments except the last one is a file, if they are not it will print the correct error message.
5. Last argument for 2 (except for the cases in 3) or more argument has to be a directory or it will report an error or otherwise it will copy the files correctly.

The inspiration of the implementation is taken from the core utilities of GNU.