### PR TITLE
Test Case for Issue#21 (mkdir hangs..) Added

### DIFF
--- a/test/test-mkdir.ts
+++ b/test/test-mkdir.ts
@@ -80,6 +80,27 @@ describe('mkdir /a', function(): void {
 			}
 		}
 	});
+	it('should error out on `mkdir -p`', function(done: MochaDone): void {
+		let stdout = '';
+		let stderr = '';
+		kernel.system('mkdir -p', onExit, onStdout, onStderr);
+		function onStdout(pid: number, out: string): void {
+			stdout += out;
+		}
+		function onStderr(pid: number, out: string): void {
+			stderr += out;
+		}
+		function onExit(pid: number, code: number): void {
+			try {
+				expect(code).to.equal(1);
+				expect(stdout).to.equal('');
+				expect(stderr).to.equal('usage: mkdir [-hp] ARGS\n');
+				done();
+			} catch (e) {
+				done(e);
+			}
+		}
+	});
 	it('should have /b/c/d', function(done: MochaDone): void {
 		kernel.fs.stat('/b/c/d', function(err: any, stat: any): void {
 			expect(err).to.be.null;


### PR DESCRIPTION
I have added a test case for mkdir hanging (Issue #21)
This test case checks for `mkdir -p` without any arguments.