### PR TITLE
rm: fix '-r' flag

### DIFF
--- a/src/bin/xargs.ts
+++ b/src/bin/xargs.ts
@@ -22,7 +22,7 @@ import {format} from 'util';
  */
 let maxArgs = 10000;           // Argument limit
 let maxChars = 4096;           // Character limit
-let command = 'echo';          // COMMAND to run TODO: change to 'echo' when supported
+let command = 'echo';          // COMMAND to run 
 let comArgs = '';              // Arguments for COMMAND
 let out = '';                  // Output
 let children: any[] = [];

--- a/test/test-rm.ts
+++ b/test/test-rm.ts
@@ -65,3 +65,84 @@ describe('rm /a', function(): void {
 		});
 	});
 });
+
+describe('rm -r /a', function(): void {
+	this.timeout(10 * MINS);
+
+	let kernel: Kernel = null;
+
+	it('should boot', function(done: MochaDone): void {
+		Boot('XmlHttpRequest', ['index.json', ROOT, true], function(err: any, freshKernel: Kernel): void {
+			expect(err).to.be.null;
+			expect(freshKernel).not.to.be.null;
+			kernel = freshKernel;
+			done();
+		});
+	});
+
+	it('should create directories /a /a/b /a/c', function(done: MochaDone): void {
+		kernel.fs.mkdir('/a', function(err: any): void {
+			expect(err).to.be.undefined;
+			done();
+		});
+		kernel.fs.mkdir('/a/b', function(err: any): void {
+			expect(err).to.be.undefined;
+			done();
+		});
+		kernel.fs.mkdir('/a/c', function(err: any): void {
+			expect(err).to.be.undefined;
+			done();
+		});
+	});
+
+	it('should create empty files /a/1, /a/b/2, /a/b/3, /a/c/4', function(done: MochaDone): void {
+		let stdout: string = '';
+		let stderr: string = '';
+		kernel.system('/usr/bin/touch /a/1 /a/b/2 /a/b/3 /a/c/4', onExit, onStdout, onStderr);
+		function onStdout(pid: number, out: string): void {
+			stdout += out;
+		}
+		function onStderr(pid: number, out: string): void {
+			stderr += out;
+		}
+		function onExit(pid: number, code: number): void {
+			try {
+				expect(code).to.equal(0);
+				expect(stdout).to.equal('');
+				expect(stderr).to.equal('');
+				done();
+			} catch (e) {
+				done(e);
+			}
+		}
+	});
+
+	it('should run `rm -r /a`', function(done: MochaDone): void {
+		let stdout: string = '';
+		let stderr: string = '';
+		kernel.system('/usr/bin/rm -r /a', onExit, onStdout, onStderr);
+		function onStdout(pid: number, out: string): void {
+			stdout += out;
+		}
+		function onStderr(pid: number, out: string): void {
+			stderr += out;
+		}
+		function onExit(pid: number, code: number): void {
+			try {
+				expect(code).to.equal(0);
+				expect(stdout).to.equal('');
+				expect(stderr).to.equal('');
+				done();
+			} catch (e) {
+				done(e);
+			}
+		}
+	});
+
+	it('should remove /a', function(done: MochaDone): void {
+		kernel.fs.stat('/a', function(err: any): void {
+			expect(err);
+			done();
+		});
+	});
+});


### PR DESCRIPTION
The '-r' flag was implmented wrong, rewrote the function using recursion
to loop over dir contents. The check for '.' and '..' is unneeded given
the node.js specification of 'fs.readdir'

`rm -rf /` seem to be failing due to missing '.deletedFiles.log' after
first iterations of the function.

Removed unnecessary comment in xargs

