### PR TITLE
Cp

### DIFF
--- a/src/bin/cp.ts
+++ b/src/bin/cp.ts
@@ -139,7 +139,10 @@ function main (): void {
 	let dest: string = args[--outstanding];
 
 	fs.stat(dest, function (oerr: any, stats: fs.Stats): void {
-		if (oerr) {
+		if (dest[dest.length - 1] === '/' && (oerr || (stats && !stats.isDirectory()))) {
+			code = 1;
+			log("target ‘%s’ is not a directory ", dest, finished);
+		} else if (oerr) {
 			if (outstanding === 1 && oerr.code === "ENOENT") {
 				copy(args[0], dest);
 			} else {

--- a/src/bin/cp.ts
+++ b/src/bin/cp.ts
@@ -141,7 +141,7 @@ function main (): void {
 	fs.stat(dest, function (oerr: any, stats: fs.Stats): void {
 		if (dest[dest.length - 1] === '/' && (oerr || (stats && !stats.isDirectory()))) {
 			code = 1;
-			log("target ‘%s’ is not a directory ", dest, finished);
+			log("target ‘%s’ is not a directory", dest, finished);
 		} else if (oerr) {
 			if (outstanding === 1 && oerr.code === "ENOENT") {
 				copy(args[0], dest);
@@ -164,7 +164,7 @@ function main (): void {
 			}
 		} else {
 			code = 1;
-			log("target ‘%s’ is not a directory ", dest, finished);
+			log("target ‘%s’ is not a directory", dest, finished);
 		}
 	});
 }

--- a/test/test-all.ts
+++ b/test/test-all.ts
@@ -18,4 +18,5 @@ require('./test-sort');
 require('./test-tee');
 require('./test-nice');
 require('./test-xargs');
+require('./test-cp');
 // require('./test-scheduler');

--- a/test/test-cp.ts
+++ b/test/test-cp.ts
@@ -244,4 +244,26 @@ describe('cp /a /b', function(): void {
             done();
         });
     });
+
+    it('should throw error when src and dest are same `cp /a /a`', function (done:MochaDone):void {
+        let stdout = '';
+        let stderr = '';
+        kernel.system('cp /a /a', onExit, onStdout, onStderr);
+        function onStdout(pid: number, out: string): void {
+            stdout += out;
+        }
+        function onStderr(pid: number, out: string): void {
+            stderr += out;
+        }
+        function onExit(pid: number, code: number): void {
+            try {
+                expect(code).to.equal(1);
+                expect(stdout).to.equal('');
+                expect(stderr).to.equal('cp: ‘/a’ and ‘/a’ are the same file\n');
+                done();
+            } catch (e) {
+                done(e);
+            }
+        }
+    });
 });

--- a/test/test-cp.ts
+++ b/test/test-cp.ts
@@ -266,4 +266,48 @@ describe('cp /a /b', function(): void {
             }
         }
     });
+
+    it('should throw error when trying to copy in a directory that doesn\'t exists', function(done: MochaDone): void {
+        let stdout = '';
+        let stderr = '';
+        kernel.system('cp /a c/', onExit, onStdout, onStderr);
+        function onStdout(pid: number, out: string): void {
+            stdout += out;
+        }
+        function onStderr(pid: number, out: string): void {
+            stderr += out;
+        }
+        function onExit(pid: number, code: number): void {
+            try {
+                expect(code).to.equal(1);
+                expect(stdout).to.equal('');
+                expect(stderr).to.equal('cp: target ‘c/’ is not a directory\n');
+                done();
+            } catch (e) {
+                done(e);
+            }
+        }
+    });
+
+    it('should throw error when trying to copy in a fs which is not a directory', function (done:MochaDone):void {
+        let stdout = '';
+        let stderr = '';
+        kernel.system('cp /a b/', onExit, onStdout, onStderr);
+        function onStdout(pid: number, out: string): void {
+            stdout += out;
+        }
+        function onStderr(pid: number, out: string): void {
+            stderr += out;
+        }
+        function onExit(pid: number, code: number): void {
+            try {
+                expect(code).to.equal(1);
+                expect(stdout).to.equal('');
+                expect(stderr).to.equal('cp: target ‘b/’ is not a directory\n');
+                done();
+            } catch (e) {
+                done(e);
+            }
+        }
+    });
 });

--- a/test/test-cp.ts
+++ b/test/test-cp.ts
@@ -1,0 +1,53 @@
+/// <reference path="../typings/globals/chai/index.d.ts" />
+/// <reference path="../typings/globals/mocha/index.d.ts" />
+
+'use strict';
+
+import * as chai from 'chai';
+import { Boot, Kernel } from '../lib/kernel/kernel';
+
+const expect = chai.expect;
+
+const MINS = 60 * 1000; // milliseconds
+
+const IS_KARMA = typeof window !== 'undefined' && typeof (<any>window).__karma__ !== 'undefined';
+const ROOT = IS_KARMA ? '/base/fs/' : '/fs/';
+
+export const name = 'test-cp';
+
+describe('cp', function(): void {
+    this.timeout(10 * MINS);
+
+    let kernel: Kernel = null;
+
+    it('should boot', function(done: MochaDone): void {
+        Boot('XmlHttpRequest', ['index.json', ROOT, true], function(err: any, freshKernel: Kernel): void {
+            expect(err).to.be.null;
+            expect(freshKernel).not.to.be.null;
+            kernel = freshKernel;
+            done();
+        });
+    });
+
+    it('should throw error when no file operand is given `cp`', function(done: MochaDone): void {
+        let stdout = '';
+        let stderr = '';
+        kernel.system('cp', onExit, onStdout, onStderr);
+        function onStdout(pid: number, out: string): void {
+            stdout += out;
+        }
+        function onStderr(pid: number, out: string): void {
+            stderr += out;
+        }
+        function onExit(pid: number, code: number): void {
+            try {
+                expect(code).to.equal(-1);
+                expect(stdout).to.equal('');
+                expect(stderr).to.equal('cp: missing file operand\n');
+                done();
+            } catch (e) {
+                done(e);
+            }
+        }
+    });
+});

--- a/test/test-cp.ts
+++ b/test/test-cp.ts
@@ -310,4 +310,50 @@ describe('cp /a /b', function(): void {
             }
         }
     });
+
+    it('should create a directory c/', function (done:MochaDone):void {
+       kernel.fs.mkdir('/c', function(err) {
+           expect(err).not.to.be.undefined;
+           done();
+       });
+    });
+
+    it('should run `cp /a c/`', function (done:MochaDone): void {
+        let stdout = '';
+        let stderr = '';
+        kernel.system('cp /a c/', onExit, onStdout, onStderr);
+        function onStdout(pid: number, out: string): void {
+            stdout += out;
+        }
+        function onStderr(pid: number, out: string): void {
+            stderr += out;
+        }
+        function onExit(pid: number, code: number): void {
+            try {
+                expect(code).to.equal(0);
+                expect(stdout).to.equal('');
+                expect(stderr).to.equal('');
+                done();
+            } catch (e) {
+                done(e);
+            }
+        }
+    });
+
+    it('should have /c/a', function (done:MochaDone):void {
+       kernel.fs.stat('/c/a', function(err: any, stat: any): void {
+           expect(err).to.be.null;
+           expect(stat).not.to.be.null;
+           expect(stat.isFile()).to.be.true;
+           done();
+       });
+    });
+
+    it('contents of /c/a and /a should be same', function (done:MochaDone):void {
+        kernel.fs.readFile('/c/a', 'utf-8', function(err: any, contents: string): void {
+            expect(err).to.be.undefined;
+            expect(contents).to.equal(B_CONTENTS);
+            done();
+        });
+    });
 });

--- a/test/test-cp.ts
+++ b/test/test-cp.ts
@@ -51,3 +51,70 @@ describe('cp', function(): void {
         }
     });
 });
+
+describe('cp /a', function(): void {
+    this.timeout(10 * MINS);
+
+    const A_CONTENTS = 'contents of a';
+    let kernel: Kernel = null;
+
+    it('should boot', function(done: MochaDone): void {
+        Boot('XmlHttpRequest', ['index.json', ROOT, true], function(err: any, freshKernel: Kernel): void {
+            expect(err).to.be.null;
+            expect(freshKernel).not.to.be.null;
+            kernel = freshKernel;
+            done();
+        });
+    });
+
+    it('should throw error when file doesn\'t and destination is missing `cp /a`', function(done: MochaDone): void {
+        let stdout = '';
+        let stderr = '';
+        kernel.system('cp /a', onExit, onStdout, onStderr);
+        function onStdout(pid: number, out: string): void {
+            stdout += out;
+        }
+        function onStderr(pid: number, out: string): void {
+            stderr += out;
+        }
+        function onExit(pid: number, code: number): void {
+            try {
+                expect(code).to.equal(-1);
+                expect(stdout).to.equal('');
+                expect(stderr).to.equal('cp: missing destination file operand after ‘/a’\n');
+                done();
+            } catch (e) {
+                done(e);
+            }
+        }
+    });
+
+    it('should create /a', function(done: MochaDone): void {
+        kernel.fs.writeFile('/a', A_CONTENTS, function(err: any): void {
+            expect(err).to.be.undefined;
+            done();
+        });
+    });
+
+    it('should throw error when file exist but destination is missing `cp /a`', function (done:MochaDone):void {
+        let stdout = '';
+        let stderr = '';
+        kernel.system('cp /a', onExit, onStdout, onStderr);
+        function onStdout(pid: number, out: string): void {
+            stdout += out;
+        }
+        function onStderr(pid: number, out: string): void {
+            stderr += out;
+        }
+        function onExit(pid: number, code: number): void {
+            try {
+                expect(code).to.equal(-1);
+                expect(stdout).to.equal('');
+                expect(stderr).to.equal('cp: missing destination file operand after ‘/a’\n');
+                done();
+            } catch (e) {
+                done(e);
+            }
+        }
+    });
+});

--- a/test/test-cp.ts
+++ b/test/test-cp.ts
@@ -378,4 +378,26 @@ describe('cp /a /b', function(): void {
             }
         }
     });
+
+    it('should throw an error when trying to copy a directory without -r', function (done:MochaDone): void {
+        let stdout = '';
+        let stderr = '';
+        kernel.system('cp /c /d', onExit, onStdout, onStderr);
+        function onStdout(pid: number, out: string): void {
+            stdout += out;
+        }
+        function onStderr(pid: number, out: string): void {
+            stderr += out;
+        }
+        function onExit(pid: number, code: number): void {
+            try {
+                expect(code).to.equal(1);
+                expect(stdout).to.equal('');
+                expect(stderr).to.equal('cp: omitting directory ‘/c’\n');
+                done();
+            } catch (e) {
+                done(e);
+            }
+        }
+    });
 });

--- a/test/test-cp.ts
+++ b/test/test-cp.ts
@@ -124,6 +124,7 @@ describe('cp /a /b', function(): void {
     this.timeout(10 * MINS);
 
     const A_CONTENTS = 'contents of a';
+    const B_CONTENTS = 'contents of b';
     let kernel: Kernel = null;
 
     it('should boot', function(done: MochaDone): void {
@@ -199,6 +200,47 @@ describe('cp /a /b', function(): void {
         kernel.fs.readFile('/b', 'utf-8', function(err: any, contents: string): void {
             expect(err).to.be.undefined;
             expect(contents).to.equal(A_CONTENTS);
+            done();
+        });
+    });
+
+    it('should change the content of /a', function(done: MochaDone): void {
+        kernel.fs.writeFile('/a', B_CONTENTS, function(err: any): void {
+            expect(err).to.be.undefined;
+            kernel.fs.readFile('/a', 'utf-8', function(err: any, contents: string): void {
+               expect(err).to.be.undefined;
+                expect(contents).to.equal(B_CONTENTS);
+                done();
+            });
+        });
+    });
+
+    it('should run `cp /a /b` when /b exists and writable', function (done:MochaDone):void {
+        let stdout = '';
+        let stderr = '';
+        kernel.system('cp /a /b', onExit, onStdout, onStderr);
+        function onStdout(pid: number, out: string): void {
+            stdout += out;
+        }
+        function onStderr(pid: number, out: string): void {
+            stderr += out;
+        }
+        function onExit(pid: number, code: number): void {
+            try {
+                expect(code).to.equal(0);
+                expect(stdout).to.equal('');
+                expect(stderr).to.equal('');
+                done();
+            } catch (e) {
+                done(e);
+            }
+        }
+    });
+
+    it('should overwrite the contents of /b', function (done: MochaDone): void {
+        kernel.fs.readFile('/b', 'utf-8', function(err: any, contents: string): void {
+            expect(err).to.be.undefined;
+            expect(contents).to.equal(B_CONTENTS);
             done();
         });
     });

--- a/test/test-cp.ts
+++ b/test/test-cp.ts
@@ -356,4 +356,26 @@ describe('cp /a /b', function(): void {
             done();
         });
     });
+
+    it('should throw an error when the copying in a directory that does not exists', function (done:MochaDone):void {
+        let stdout = '';
+        let stderr = '';
+        kernel.system('cp /a d/b', onExit, onStdout, onStderr);
+        function onStdout(pid: number, out: string): void {
+            stdout += out;
+        }
+        function onStderr(pid: number, out: string): void {
+            stderr += out;
+        }
+        function onExit(pid: number, code: number): void {
+            try {
+                expect(code).to.equal(1);
+                expect(stdout).to.equal('');
+                expect(stderr).not.to.be.empty;
+                done();
+            } catch (e) {
+                done(e);
+            }
+        }
+    });
 });


### PR DESCRIPTION
Corrects typo in error message in cp
Checks the condition when destination ends with a '/'
Adds test cases for cp cmd
